### PR TITLE
Fix issues found with -Wstrict-prototypes

### DIFF
--- a/c2d.c
+++ b/c2d.c
@@ -49,7 +49,7 @@ Bugs:
 #define MONITOR 1
 #define LOADER "loader"
 
-void usage();
+void usage(void);
 char *getext(char *filename);
 
 int main(int argc, char **argv)
@@ -346,7 +346,7 @@ char *getext(char *filename)
 	return (rval);
 }
 
-void usage()
+void usage(void)
 {
 	fprintf(stderr, "%s", usagetext);
 }

--- a/page2text.c
+++ b/page2text.c
@@ -2,7 +2,7 @@
 
 #define MASK 0x7F
 
-int main()
+int main(int argc, char **argv)
 {
 	int i, j, k, line;
 	char screen[24][40];

--- a/text2page.c
+++ b/text2page.c
@@ -3,7 +3,7 @@
 #define NORMAL 0x80
 #define BLINK 0x40
 
-int main()
+int main(int argc, char **argv)
 {
 	char c;
 	int i, j, k, line = 0;


### PR DESCRIPTION
This fixes warnings seen when using `-Wstrict-prototypes` with clang 17:

```
c2d.c:52:11: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
   52 | void usage();
      |           ^
      |            void
```
```
c2d.c:353:11: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
  353 | void usage()
      |           ^
      |            void
```
```
text2page.c:6:9: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
    6 | int main()
      |         ^
      |          void
```
```
page2text.c:5:9: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
    5 | int main()
      |         ^
      |          void
```

Instead of using `void` for the `main` functions, though, I used the same parameters you had used for `main` in c2d.c.